### PR TITLE
fix cask_url

### DIFF
--- a/Casks/wechsel.rb
+++ b/Casks/wechsel.rb
@@ -2,7 +2,7 @@ cask 'wechsel' do
   version '1.0.1'
   sha256 '37352e2eaea28c7021ffed50f59934185f5858bfbdac932f352efcda2b1d743a'
 
-  url 'https://github.com/friedrichweise/wechsel/releases/download/v1.01/wechsel_v1.0.1.zip'
+  url 'https://github.com/friedrichweise/wechsel/releases/download/v1.0.1/wechsel_v1.0.1.zip'
   appcast 'https://github.com/friedrichweise/wechsel/releases.atom'
   name 'wechsel'
   homepage 'https://wechsel.weise.io'


### PR DESCRIPTION
As the URL of cask was 404, it was corrected

```
% brew cask install wechsel
==> Satisfying dependencies
==> Downloading https://github.com/friedrichweise/wechsel/releases/download/v1.01/wechsel_v1.0.1.zip

curl: (22) The requested URL returned error: 404 Not Found
Error: Download failed on Cask 'wechsel' with message: Download failed: https://github.com/friedrichweise/wechsel/releases/download/v1.01/wechsel_v1.0.1.zip
```